### PR TITLE
Fix k8s scrape config to work with prometheus 1.4.1

### DIFF
--- a/k8s/prometheus-k8s.yml
+++ b/k8s/prometheus-k8s.yml
@@ -7,9 +7,8 @@ scrape_configs:
   metrics_path: /admin/metrics/prometheus
 
   kubernetes_sd_configs:
-  - api_servers:
-    - 'http://localhost:8001'
-    role: endpoint
+  - api_server: 'http://localhost:8001'
+    role: endpoints
 
   relabel_configs:
   # only collect from linkerd's


### PR DESCRIPTION
Looks like the `kubernetes_sd_configs` scrape target fields changes with the new version of prometheus. This updates our kubernetes config to use the correct fields. Fixes #14.